### PR TITLE
THULLO-86: Implement functionality to maintain the active state of the task modal

### DIFF
--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -9,3 +9,7 @@ Q
 !src/components/DragAndDropBox.tsx,7/7/7730701214bf7d1dec6bbd54384c6af46726771e
 N
 src/components/CommentList.tsx,e/5/e562cd53d9666b8244ec50f7af7061d9ccafa5d9
+P
+ .github/pull_request_template.md,9/9/99d2d4406193bf0dc3e7b84a6c9b9109997a4864
+J
+src/actions/taskActions.ts,9/8/980198367ecd500a76d9325d78aaedd126b5a631

--- a/src/components/DragDropCard.tsx
+++ b/src/components/DragDropCard.tsx
@@ -19,13 +19,14 @@ const DragDropCard = ({
   const dispatchFn = useAppDispatch();
 
   const displayTaskModal = () => {
-    dispatchFn(
-      boardAction.toggleDisplayTaskModal({
-        cardId: card.id,
-        columnId: columnId,
-      })
-    );
+    const newTaskModal = {
+      cardId: card.id,
+      columnId: columnId,
+    };
+    dispatchFn(boardAction.toggleDisplayTaskModal(newTaskModal));
+    localStorage.setItem("activeTaskModal", JSON.stringify(newTaskModal));
   };
+
 
   return (
     <Draggable draggableId={String(card.id)} index={index}>

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -19,20 +19,18 @@ import AddMemberModal from "./AddMemberModal";
 import ImageCache from "./ImageCache";
 import { updateTaskCoverImage } from "../actions/taskActions";
 
-interface Btns {
+interface Btn {
   title: string;
   icon: ReactElement;
 }
 
-const actionBtns: Btns[] = [
+const actionBtn: Btn[] = [
   {
     title: "Cover",
-
     icon: <AiFillPicture className="text-current w-2.5 h-2.5 mr-3" />,
   },
   {
     title: "Labels",
-
     icon: <MdLabel className="text-current w-2.5 h-2.5 mr-3" />,
   },
   {
@@ -41,7 +39,7 @@ const actionBtns: Btns[] = [
   },
 ];
 
-const TaskModal = ({ boardId }: { boardId: number }) => {
+const TaskModal = () => {
   const dispatchFn = useAppDispatch();
   const [addMemberModal, setAddMemberModal] = useState(false);
   const [displayModal, setDisplayModal] = useState("");
@@ -72,6 +70,7 @@ const TaskModal = ({ boardId }: { boardId: number }) => {
           columnId: undefined,
         })
       );
+      localStorage.setItem("activeTaskModal", "");
     }
   };
 
@@ -123,6 +122,7 @@ const TaskModal = ({ boardId }: { boardId: number }) => {
                     columnId: undefined,
                   })
                 );
+                localStorage.setItem("activeTaskModal", "");
               }}
             >
               <RxCross2 className="w-6 h-6" />
@@ -154,7 +154,7 @@ const TaskModal = ({ boardId }: { boardId: number }) => {
                 <FaUserCircle className="text-current w-2.5 h-2.5 mr-2" />
                 Actions
               </p>
-              {actionBtns.map((btn: Btns, i) => (
+              {actionBtn.map((btn: Btn, i) => (
                 <button
                   key={i}
                   className={`flex w-full items-center  rounded-lg py-1.5 px-2.5 mb-3 text-color-grey-3 font-medium text-sm ${

--- a/src/pages/user/BoardDetail.tsx
+++ b/src/pages/user/BoardDetail.tsx
@@ -1,109 +1,120 @@
-import React from "react";
-// import { IoMdLock } from "react-icons/io";
-import { BsPlusLg } from "react-icons/bs";
-import { BsThreeDots } from "react-icons/bs";
+import React, {useEffect, useState} from "react";
+import {BsPlusLg} from "react-icons/bs";
+import {BsThreeDots} from "react-icons/bs";
 import DragAndDropBox from "../../components/DragAndDropBox";
 import AddAnotherColumnForm from "../../components/AddAnotherColumnForm";
-import { useAppSelector, useAppDispatch } from "../../hooks/customHook";
-import { Board } from "../../utils/types";
-import { boardAction } from "../../slice/boardSlice";
+import {useAppSelector, useAppDispatch} from "../../hooks/customHook";
+import {Board} from "../../utils/types";
+import {boardAction} from "../../slice/boardSlice";
 import TaskModal from "../../components/TaskModal";
 
 const BoardDetail = () => {
-  const dispatchFn = useAppDispatch();
+    const dispatchFn = useAppDispatch();
+    const [taskModal, setTaskModal] = useState<any>(null);
 
-  const displayTaskModal = useAppSelector(
-    (state) => state.board.displayTaskModal
-  );
+    useEffect(() => {
+        const activeTaskModal = localStorage.getItem("activeTaskModal");
+        if (activeTaskModal) {
+            setTaskModal(JSON.parse(activeTaskModal));
+        }
+    }, []);
 
-  const displayAddColumnFormHandler = () => {
-    dispatchFn(boardAction.toggleDispayAddColumnForm(true));
-  };
+    useEffect(() => {
+        if (taskModal) {
+            dispatchFn(boardAction.toggleDisplayTaskModal(taskModal));
+        }
+    }, [taskModal, dispatchFn]);
 
-  const boardItem: Board = useAppSelector((state) => state.board.boardItem);
+    const displayTaskModal = useAppSelector((state) => state.board.displayTaskModal);
 
-  const displayAddColumnForm = useAppSelector(
-    (state) => state.board.displayAddColumnForm
-  );
+    const displayAddColumnFormHandler = () => {
+        dispatchFn(boardAction.toggleDispayAddColumnForm(true));
+    };
 
-  const isImage = (url: string) => {
-    return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
-  };
+    const boardItem: Board = useAppSelector((state) => state.board.boardItem);
 
-  const closeForms: any = (e: { target: { dataset: { close: string } } }) => {
-    if (e.target.dataset.close) {
-      dispatchFn(boardAction.toggleDispayAddColumnForm(false));
-    }
-  };
+    const displayAddColumnForm = useAppSelector(
+        (state) => state.board.displayAddColumnForm
+    );
 
-  return (
-    <section
-      className="flex items-center flex-col px-8 pb-4 h-[calc(100vh-5rem)] sm:px-4"
-      data-close="yes"
-      onClick={closeForms}
-    >
-      <div className="flex items-center my-8 w-full sm:mt-[4rem]  sm:flex-wrap sm:justify-between">
-        {/* <p className="flex items-center bg-color-grey-1 rounded-lg py-2 px-4 cursor-pointer text-xs text-color-grey-3 sm:order-1">
+    const isImage = (url: string) => {
+        return /\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(url);
+    };
+
+    const closeForms: any = (e: { target: { dataset: { close: string } } }) => {
+        if (e.target.dataset.close) {
+            dispatchFn(boardAction.toggleDispayAddColumnForm(false));
+        }
+    };
+
+    return (
+        <section
+            className="flex items-center flex-col px-8 pb-4 h-[calc(100vh-5rem)] sm:px-4"
+            data-close="yes"
+            onClick={closeForms}
+        >
+            <div className="flex items-center my-8 w-full sm:mt-[4rem]  sm:flex-wrap sm:justify-between">
+                {/* <p className="flex items-center bg-color-grey-1 rounded-lg py-2 px-4 cursor-pointer text-xs text-color-grey-3 sm:order-1">
           {boardItem.privateState && (
             <IoMdLock className="w-3 h-3 text-current mr-2" />
           )}
           {boardItem.privateState ? "Private" : "Public"}
         </p> */}
 
-        <div className="flex items-center  sm:ml-0 sm:order-3 sm:w-full sm:mt-1">
-          {boardItem.collaborators && boardItem.collaborators.length > 0
-            ? boardItem.collaborators.map((userAvatar: string, i: number) => {
-                return isImage(userAvatar) ? (
-                  <img
-                    src={userAvatar}
-                    alt="collab-img"
-                    key={i}
-                    className={`w-8 h-8 mr-1 sm:w-9 sm:h-9 relative rounded-full ${
-                      i === 0 ? "z-20" : i === 1 ? "z-10" : "z-0"
-                    }`}
-                  />
-                ) : (
-                  <p
-                    key={i}
-                    className="w-8 h-8 flex items-center justify-center bg-[#BDBDBD] mr-1 text-color-white rounded-lg text-xs"
-                  >
-                    {userAvatar.slice(0, 2).toUpperCase()}
-                  </p>
-                );
-              })
-            : ""}
-          <div
-            className={`w-8 h-8 flex items-center rounded-lg justify-center bg-color-btn cursor-pointer`}
-          >
-            <BsPlusLg className="text-color-white " />
-          </div>
-        </div>
+                <div className="flex items-center  sm:ml-0 sm:order-3 sm:w-full sm:mt-1">
+                    {boardItem.collaborators && boardItem.collaborators.length > 0
+                        ? boardItem.collaborators.map((userAvatar: string, i: number) => {
+                            return isImage(userAvatar) ? (
+                                <img
+                                    src={userAvatar}
+                                    alt="collab-img"
+                                    key={i}
+                                    className={`w-8 h-8 mr-1 sm:w-9 sm:h-9 relative rounded-full ${
+                                        i === 0 ? "z-20" : i === 1 ? "z-10" : "z-0"
+                                    }`}
+                                />
+                            ) : (
+                                <p
+                                    key={i}
+                                    className="w-8 h-8 flex items-center justify-center bg-[#BDBDBD] mr-1 text-color-white rounded-lg text-xs"
+                                >
+                                    {userAvatar.slice(0, 2).toUpperCase()}
+                                </p>
+                            );
+                        })
+                        : ""}
+                    <div
+                        className={`w-8 h-8 flex items-center rounded-lg justify-center bg-color-btn cursor-pointer`}
+                    >
+                        <BsPlusLg className="text-color-white "/>
+                    </div>
+                </div>
 
-        <p className="ml-auto flex items-center bg-color-grey-1 rounded-lg py-2 px-4 cursor-pointer text-xs text-color-grey-3 sm:order-2">
-          <BsThreeDots className="w-3 h-3 text-current mr-2" />
-          Show Menu
-        </p>
-      </div>
-      <div
-        className="w-full bg-[#F8F9FD] rounded-lg p-7 grid grid-cols-5 xl:grid-cols-17 gap-7 overflow-auto flex-1 items-start scroll "
-        data-close="yes"
-      >
-        <DragAndDropBox />
-        {!displayAddColumnForm && (
-          <button
-            className="bg-[#DAE4FD] flex text-[#2F80ED] justify-between items-center py-2 px-3.5 rounded-lg"
-            onClick={displayAddColumnFormHandler}
-          >
-            Add another list
-            <BsPlusLg className="text-current " />
-          </button>
-        )}
-        {displayAddColumnForm && <AddAnotherColumnForm />}
-      </div>
+                <p className="ml-auto flex items-center bg-color-grey-1 rounded-lg py-2 px-4 cursor-pointer text-xs text-color-grey-3 sm:order-2">
+                    <BsThreeDots className="w-3 h-3 text-current mr-2"/>
+                    Show Menu
+                </p>
+            </div>
+            <div
+                className="w-full bg-[#F8F9FD] rounded-lg p-7 grid grid-cols-5 xl:grid-cols-17 gap-7 overflow-auto flex-1 items-start scroll "
+                data-close="yes"
+            >
+                <DragAndDropBox/>
+                {!displayAddColumnForm && (
+                    <button
+                        className="bg-[#DAE4FD] flex text-[#2F80ED] justify-between items-center py-2 px-3.5 rounded-lg"
+                        onClick={displayAddColumnFormHandler}
+                    >
+                        Add another list
+                        <BsPlusLg className="text-current "/>
+                    </button>
+                )}
+                {displayAddColumnForm && <AddAnotherColumnForm/>}
+            </div>
 
-      {displayTaskModal && <TaskModal boardId={boardItem.id} />}
-    </section>
-  );
+            {displayTaskModal && <TaskModal/>}
+        </section>
+    );
 };
 
 export default BoardDetail;

--- a/src/slice/boardSlice.ts
+++ b/src/slice/boardSlice.ts
@@ -71,8 +71,6 @@ const boardSlice = createSlice({
       ];
 
       const item = state.boardItem;
-
-      // localStorage.setItem("boardList", JSON.stringify(list));
       localStorage.setItem("boardItem", JSON.stringify(item));
     },
     moveTaskWithinBoardTaskColumn(
@@ -127,6 +125,7 @@ const boardSlice = createSlice({
     toggleDispayAddColumnForm(state: any, action: { payload: boolean }) {
       state.displayAddColumnForm = action.payload;
     },
+
     toggleDisplayTaskModal(
       state: any,
       action: {


### PR DESCRIPTION
## Pull Request Description
Implement functionality to maintain the active state of the task modal

## Related Issue
https://thullo.atlassian.net/browse/THULLO-86

## Changes Made
The details of the current task modal that is open are stored in local storage. If the cancel button is clicked to close the modal, the local storage task modal is set to empty data. However, when the page is refreshed, the data is fetched from local storage using state and useEffect. If the data is valid, the action is dispatched to activate the task modal.

## Screenshots or GIFs (if applicable)

## How to Test

## Checklist
- [ ] I have followed the project's code style guidelines ✅
- [ ] My changes are documented appropriately ✅
- [ ] I have added/updated tests for my changes 
- [ ] My code builds without any errors or warnings ✅
- [ ] My changes do not introduce any new linting errors or warnings ✅

## Additional Notes
