### PR TITLE
Thullo 52

### DIFF
--- a/src/actions/boardAction.ts
+++ b/src/actions/boardAction.ts
@@ -3,8 +3,7 @@ import {
   createBoard,
   getBoard,
   getAllBoards,
-  updateBoardImage,
-  editBoardName,
+  editBoard,
 } from "../services/boardService";
 import { boardAction } from "../slice/boardSlice";
 
@@ -16,7 +15,6 @@ export const addBoard = (file: any, boardName: string) => {
       const response: any = await createBoard(file, boardName);
       dispatch(boardAction.setIsLoading(false));
       toastSuccess(extractMessage(response.data.message));
-      console.log(response);
 
       // dispatching an action that adds board to boardList
       dispatch(boardAction.addBoardToBoardList(response.data.data));
@@ -48,7 +46,6 @@ export const getBoards = () => {
   return async (dispatch: Function) => {
     try {
       const response: any = await getAllBoards();
-      console.log(response);
       // dispatching an action that adds board to boardList
       dispatch(boardAction.getAllBoards(response.data.data));
     } catch (err) {
@@ -60,48 +57,31 @@ export const getBoards = () => {
   };
 };
 
-export const updateBoardImageAction = ({
-  boardTag,
-  file,
-  imageUrl,
-}: {
-  boardTag: string;
-  imageUrl: string | undefined;
-  file: any;
-}) => {
-  return async (dispatch: Function) => {
-    try {
-      dispatch(boardAction.updateBoardImage({ boardTag, imageUrl }));
-
-      await updateBoardImage({
-        boardTag,
-        file,
-      });
-    } catch (err) {
-      dispatch(boardAction.setError(true));
-      const errorMsg = extractMessage(err);
-      toastError(extractMessage(errorMsg));
-      dispatch(boardAction.setErrorMsg(errorMsg));
-    }
-  };
-};
-
-export const editBoardNameAction = ({
+export const editBoardAction = ({
   boardTag,
   name,
+  file,
+  imageUrl,
+  visibility,
 }: {
   boardTag: string;
   name: string;
+  file: any;
+  imageUrl: string;
+  visibility: string;
 }) => {
   return async (dispatch: Function) => {
     try {
-      dispatch(boardAction.editBoardName({ boardTag, name }));
+      dispatch(
+        boardAction.editBoardItem({ boardTag, name, imageUrl, visibility })
+      );
 
-      const response = await editBoardName({
+      await editBoard({
         boardTag,
         name,
+        file,
+        visibility,
       });
-      console.log(response);
     } catch (err) {
       dispatch(boardAction.setError(true));
       const errorMsg = extractMessage(err);

--- a/src/components/BoardItem.tsx
+++ b/src/components/BoardItem.tsx
@@ -15,6 +15,7 @@ const BoardItem = ({
   boardRef,
   boardTag,
   boardId,
+  boardVisibility,
   displayUpdateBoardModal,
   setDisplayUpdateBoardModal,
 }: {
@@ -24,12 +25,10 @@ const BoardItem = ({
   boardRef: string;
   boardTag: string;
   boardId: number;
+  boardVisibility: string;
   displayUpdateBoardModal: null | number;
   setDisplayUpdateBoardModal: Function;
 }) => {
-  // const [displayUpdateBoardModal, setDisplayUpdateBoardModal] =
-  //   useState<boolean>(false);
-
   const [displayEditBoardForm, setDisplayEditBoardForm] =
     useState<boolean>(false);
 
@@ -59,21 +58,23 @@ const BoardItem = ({
       className="bg-color-white p-3 rounded-lg shadow-3xl  cursor-pointer relative"
       data-closeinput="true"
     >
-      <div
-        className="rounded-lg  w-full h-[10rem] overflow-hidden"
-        onClick={viewBoardHandler}
-      >
-        <img
-          src={img || noImage}
-          data-board={boardRef}
-          alt="board-img"
-          className=" hover:scale-[1.1] object-cover w-full h-[10rem] relative transition-all duration-300 ease-linear"
-        />
-      </div>
       {!displayEditBoardForm && (
-        <div className="flex justify-between items-center">
+        <div
+          className="rounded-lg  w-full h-[10rem] overflow-hidden"
+          onClick={viewBoardHandler}
+        >
+          <img
+            src={img || noImage}
+            data-board={boardRef}
+            alt="board-img"
+            className=" hover:scale-[1.1] object-cover w-full h-[10rem] relative transition-all duration-300 ease-linear"
+          />
+        </div>
+      )}
+      {!displayEditBoardForm && (
+        <div className="flex justify-between items-center my-4 ">
           <p
-            className="mb-4 mt-2 font-semibold capitalize cursor-pointer"
+            className=" font-semibold capitalize cursor-pointer"
             onClick={viewBoardHandler}
             data-board={boardRef}
           >
@@ -118,13 +119,15 @@ const BoardItem = ({
         <EditBoardNameForm
           setDisplayEditBoardNameForm={setDisplayEditBoardForm}
           boardTag={boardTag}
+          img={img}
+          boardVisibility={boardVisibility}
+          boardName={boardName}
         />
       )}
       <UpdateBoardDetailsModal
         boardId={boardId}
         display={displayUpdateBoardModal}
         setDisplay={setDisplayUpdateBoardModal}
-        boardTag={boardTag}
         setDisplayEditBoardForm={setDisplayEditBoardForm}
       />
     </div>

--- a/src/components/BoardItem.tsx
+++ b/src/components/BoardItem.tsx
@@ -6,28 +6,33 @@ import noImage from "../asset/img/no-image.jpg";
 import { BsThreeDots } from "react-icons/bs";
 import UpdateBoardDetailsModal from "./UpdateBoardDetailsModal";
 import EditBoardNameForm from "./EditBoardNameForm";
+import { useState } from "react";
 
 const BoardItem = ({
   img,
   boardName,
   collaborators,
   boardRef,
-  display,
-  setDisplay,
   boardTag,
-  displayEditBoardNameForm,
-  setDisplayEditBoardNameForm,
+  boardId,
+  displayUpdateBoardModal,
+  setDisplayUpdateBoardModal,
 }: {
   img: string;
   boardName: string;
   collaborators: string[] | undefined;
   boardRef: string;
-  display: boolean;
-  displayEditBoardNameForm: boolean;
   boardTag: string;
-  setDisplay: Function;
-  setDisplayEditBoardNameForm: Function;
+  boardId: number;
+  displayUpdateBoardModal: null | number;
+  setDisplayUpdateBoardModal: Function;
 }) => {
+  // const [displayUpdateBoardModal, setDisplayUpdateBoardModal] =
+  //   useState<boolean>(false);
+
+  const [displayEditBoardForm, setDisplayEditBoardForm] =
+    useState<boolean>(false);
+
   const dispatchFn = useAppDispatch();
   const navigate = useNavigate();
 
@@ -46,18 +51,13 @@ const BoardItem = ({
   };
 
   const displayUpdateBoardModalHandler = () => {
-    setDisplay(true);
+    setDisplayUpdateBoardModal(boardId);
   };
 
   return (
     <div
       className="bg-color-white p-3 rounded-lg shadow-3xl  cursor-pointer relative"
       data-closeinput="true"
-      onClick={(e: any) => {
-        if (e.target.dataset.closeinput) {
-          setDisplayEditBoardNameForm(false);
-        }
-      }}
     >
       <div
         className="rounded-lg  w-full h-[10rem] overflow-hidden"
@@ -70,7 +70,7 @@ const BoardItem = ({
           className=" hover:scale-[1.1] object-cover w-full h-[10rem] relative transition-all duration-300 ease-linear"
         />
       </div>
-      {!displayEditBoardNameForm && (
+      {!displayEditBoardForm && (
         <div className="flex justify-between items-center">
           <p
             className="mb-4 mt-2 font-semibold capitalize cursor-pointer"
@@ -114,17 +114,18 @@ const BoardItem = ({
           </small>
         )}
       </div>
-      {displayEditBoardNameForm && (
+      {displayEditBoardForm && (
         <EditBoardNameForm
-          setDisplayEditBoardNameForm={setDisplayEditBoardNameForm}
+          setDisplayEditBoardNameForm={setDisplayEditBoardForm}
           boardTag={boardTag}
         />
       )}
       <UpdateBoardDetailsModal
-        display={display}
-        setDisplay={setDisplay}
+        boardId={boardId}
+        display={displayUpdateBoardModal}
+        setDisplay={setDisplayUpdateBoardModal}
         boardTag={boardTag}
-        setDisplayEditBoardNameForm={setDisplayEditBoardNameForm}
+        setDisplayEditBoardForm={setDisplayEditBoardForm}
       />
     </div>
   );

--- a/src/components/EditBoardNameForm.tsx
+++ b/src/components/EditBoardNameForm.tsx
@@ -2,16 +2,50 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import InputComponent from "./InputComponent";
 import { registrationOption } from "../utils/formValidation";
 import { useAppDispatch } from "../hooks/customHook";
-import { editBoardNameAction } from "../actions/boardAction";
+import { editBoardAction } from "../actions/boardAction";
+import { AiFillPicture, AiFillUnlock } from "react-icons/ai";
+import { useState } from "react";
+import { IoMdLock } from "react-icons/io";
+import { fileHandler } from "../utils/helperFn";
+import ReactLoading from "react-loading";
 
 const EditBoardNameForm = ({
   setDisplayEditBoardNameForm,
   boardTag,
+  img,
+  boardVisibility,
+  boardName,
 }: {
   boardTag: string;
   setDisplayEditBoardNameForm: Function;
+  img: string;
+  boardVisibility: string;
+  boardName: string;
 }) => {
   const dispatchFn = useAppDispatch();
+  const [boardImg, setBoardImg] = useState(img);
+  const [visibility, setVisibility] = useState(boardVisibility);
+  const [isLoading, setIsLoading] = useState(false);
+  const [file, setFile] = useState<any>();
+  const [clickVisibility, setClickVisibility] = useState(false);
+
+  const toggleClickVisibilityHandler = () => {
+    setClickVisibility((prevState) => !prevState);
+  };
+
+  const togglePrivateHandler = () => {
+    if (visibility === "PRIVATE") {
+      setVisibility("PUBLIC");
+    } else {
+      setVisibility("PRIVATE");
+    }
+  };
+
+  const imageHandler = (e: { target: { files: any } }) => {
+    setFile(e.target.files[0]);
+    // @ts-ignore
+    setBoardImg(fileHandler(e));
+  };
 
   type FormData = {
     boardName: string;
@@ -23,21 +57,36 @@ const EditBoardNameForm = ({
     formState: { errors },
   } = useForm<FormData>({
     defaultValues: {
-      boardName: "",
+      boardName: boardName,
     },
   });
 
   const onSubmit: SubmitHandler<FormData> = async (data) => {
-    dispatchFn(
-      editBoardNameAction({ boardTag: boardTag, name: data.boardName })
+    setIsLoading(true);
+    await dispatchFn(
+      editBoardAction({
+        boardTag: boardTag,
+        name: data.boardName,
+        file: file,
+        imageUrl: boardImg,
+        visibility: visibility,
+      })
     );
+    setIsLoading(false);
     setDisplayEditBoardNameForm(false);
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <label htmlFor="board-img">
+        <img
+          src={boardImg}
+          alt="board-img"
+          className="h-[4rem] object-cover w-full rounded-lg"
+        />
+      </label>
       <InputComponent
-        placeholder={"Add board title"}
+        placeholder={"Edit board title"}
         type={"text"}
         register={register}
         error={errors}
@@ -47,6 +96,79 @@ const EditBoardNameForm = ({
         shadow="drop-shadow-[0_1px_3px_rgba(0,0,0,0.25)]"
         autoFocus={true}
       />
+      <div className="flex items-center">
+        <label
+          htmlFor="board-img"
+          className={
+            "font-medium cursor-pointer text-sm bg-color-grey-1 rounded-lg border-0 py-1.5 px-3 flex items-center text-color-grey-3 mr-4 grow"
+          }
+        >
+          <AiFillPicture className="mr-3 w-5 h-5 text-color-grey-3" />
+          <span>Cover</span>
+        </label>
+        <input
+          type="file"
+          onChange={imageHandler}
+          accept="image/*"
+          id="board-img"
+          className="hidden"
+        />
+        <p
+          className={`font-medium cursor-pointer text-sm  rounded-lg border-0 py-1.5 px-2 flex items-center  grow  
+          ${
+            clickVisibility
+              ? "bg-color-btn text-color-white"
+              : "bg-color-grey-1 text-color-grey-3"
+          }`}
+          onClick={() => {
+            togglePrivateHandler();
+            toggleClickVisibilityHandler();
+          }}
+        >
+          {boardVisibility === "PRIVATE" ? (
+            <AiFillUnlock
+              className={`mr-3 w-5 h-5
+                  text-color-current`}
+            />
+          ) : (
+            <IoMdLock
+              className={`mr-3 w-5 h-5
+                  text-color-current
+              `}
+            />
+          )}
+          <span className="text-color-current">
+            {boardVisibility === "PRIVATE" ? "Public" : "Private"}
+          </span>
+        </p>
+      </div>
+      <div className="flex items-center justify-end mt-4">
+        <button
+          className="border-0 outline-none text-[#828282] mr-3 hover:text-color-btn transition-all duration-300 ease-in"
+          onClick={() => {
+            setDisplayEditBoardNameForm(false);
+          }}
+        >
+          cancel
+        </button>
+        <button
+          type="submit"
+          className={`font-medium cursor-pointer text-sm  rounded-lg border-0 ${
+            isLoading ? "py-0" : "py-1"
+          }  px-2 flex items-center bg-color-btn text-color-white`}
+        >
+          {isLoading && (
+            <ReactLoading type="bubbles" color="#fff" width={30} height={30} />
+          )}
+          {isLoading ? (
+            ""
+          ) : (
+            <>
+              <span className="text-base">save</span>
+            </>
+          )}
+        </button>
+      </div>
     </form>
   );
 };

--- a/src/components/UpdateBoardDetailsModal.tsx
+++ b/src/components/UpdateBoardDetailsModal.tsx
@@ -35,27 +35,29 @@ function AddImageComponent({ boardTag }: { boardTag: string }) {
 }
 
 const UpdateBoardDetailsModal = ({
+  boardId,
   display,
   setDisplay,
   boardTag,
-  setDisplayEditBoardNameForm,
+  setDisplayEditBoardForm,
 }: {
-  display: boolean;
+  boardId: number;
+  display: null | number;
   setDisplay: Function;
   boardTag: string;
-  setDisplayEditBoardNameForm: Function;
+  setDisplayEditBoardForm: Function;
 }) => {
-  function editBoardName() {
-    setDisplayEditBoardNameForm(true);
+  function displayEditBoardFormHandler() {
+    setDisplayEditBoardForm(true);
   }
 
   function deleteBoard() {}
 
   const updateItems = [
     {
-      title: "Edit Board Name",
+      title: "Edit Board",
       icon: <FiEdit className="text-current mr-3" />,
-      function: editBoardName,
+      function: displayEditBoardFormHandler,
     },
     {
       title: "Delete Board",
@@ -67,15 +69,15 @@ const UpdateBoardDetailsModal = ({
   return (
     <div
       className={`absolute top-[12rem] -right-[2rem] transition-all duration-900 ease-in-out shadow-update-board bg-color-white rounded-lg   ${
-        display
-          ? "opacity-100 visible scale-100 -translate-y-5"
+        display === boardId
+          ? "opacity-100 visible scale-100 -translate-y-5 z-50"
           : "opacity-0 hidden scale-0 translate-y-0"
       }`}
       onClick={() => {
         setDisplay(false);
       }}
     >
-      <AddImageComponent boardTag={boardTag} />
+      {/* <AddImageComponent boardTag={boardTag} /> */}
       {updateItems.map((item: any, i: number) => (
         <p
           key={i}

--- a/src/components/UpdateBoardDetailsModal.tsx
+++ b/src/components/UpdateBoardDetailsModal.tsx
@@ -1,50 +1,15 @@
 import { FiEdit } from "react-icons/fi";
-import { AiOutlineDelete, AiOutlinePicture } from "react-icons/ai";
-import { fileHandler } from "../utils/helperFn";
-import { useAppDispatch } from "../hooks/customHook";
-import { updateBoardImageAction } from "../actions/boardAction";
-
-function AddImageComponent({ boardTag }: { boardTag: string }) {
-  const dispatchFn = useAppDispatch();
-
-  const setImageHandler = (e: any) => {
-    const file = e.target.files[0];
-    const imageUrl = fileHandler(e);
-
-    dispatchFn(updateBoardImageAction({ file, imageUrl, boardTag }));
-  };
-
-  return (
-    <div>
-      <label
-        htmlFor="boardImage"
-        className="flex items-center p-2 cursor-pointer hover:text-color-btn transition-all duration-150 ease-in"
-      >
-        <AiOutlinePicture className="text-current mr-3" />
-        <span className="">Change Board Image</span>
-      </label>
-      <input
-        id="boardImage"
-        type="file"
-        className="hidden"
-        accept="image/*"
-        onChange={setImageHandler}
-      />
-    </div>
-  );
-}
+import { AiOutlineDelete } from "react-icons/ai";
 
 const UpdateBoardDetailsModal = ({
   boardId,
   display,
   setDisplay,
-  boardTag,
   setDisplayEditBoardForm,
 }: {
   boardId: number;
   display: null | number;
   setDisplay: Function;
-  boardTag: string;
   setDisplayEditBoardForm: Function;
 }) => {
   function displayEditBoardFormHandler() {
@@ -74,10 +39,9 @@ const UpdateBoardDetailsModal = ({
           : "opacity-0 hidden scale-0 translate-y-0"
       }`}
       onClick={() => {
-        setDisplay(false);
+        setDisplay(null);
       }}
     >
-      {/* <AddImageComponent boardTag={boardTag} /> */}
       {updateItems.map((item: any, i: number) => (
         <p
           key={i}

--- a/src/pages/user/DashboardMain.tsx
+++ b/src/pages/user/DashboardMain.tsx
@@ -8,10 +8,10 @@ import { Board } from "../../utils/types";
 const DashboardMain = () => {
   const [displayAddBoardModal, setDisplayAddBoardModal] =
     useState<boolean>(false);
-  const [displayUpdateBoardModal, setDisplayUpdateBoardModal] =
-    useState<boolean>(false);
-  const [displayEditBoardNameForm, setDisplayEditBoardNameForm] =
-    useState<boolean>(false);
+
+  const [displayUpdateBoardModal, setDisplayUpdateBoardModal] = useState<
+    null | number
+  >(null);
 
   const dispatchFn = useAppDispatch();
 
@@ -30,8 +30,7 @@ const DashboardMain = () => {
     target: { dataset: { close: string } };
   }) => {
     if (e.target.dataset.close) {
-      setDisplayUpdateBoardModal(false);
-      setDisplayEditBoardNameForm(false);
+      setDisplayUpdateBoardModal(null);
     }
   };
 
@@ -58,16 +57,15 @@ const DashboardMain = () => {
           >
             {boardList.map((board: Board, i) => (
               <BoardItem
-                key={i}
+                key={board.id}
+                boardId={board.id}
                 img={board.imageUrl}
                 boardTag={board.boardTag}
                 boardName={board.name}
                 collaborators={board.collaborators}
                 boardRef={board.boardTag}
-                display={displayUpdateBoardModal}
-                setDisplay={setDisplayUpdateBoardModal}
-                displayEditBoardNameForm={displayEditBoardNameForm}
-                setDisplayEditBoardNameForm={setDisplayEditBoardNameForm}
+                displayUpdateBoardModal={displayUpdateBoardModal}
+                setDisplayUpdateBoardModal={setDisplayUpdateBoardModal}
               />
             ))}
           </div>

--- a/src/pages/user/DashboardMain.tsx
+++ b/src/pages/user/DashboardMain.tsx
@@ -62,6 +62,7 @@ const DashboardMain = () => {
                 img={board.imageUrl}
                 boardTag={board.boardTag}
                 boardName={board.name}
+                boardVisibility={board.boardVisibility}
                 collaborators={board.collaborators}
                 boardRef={board.boardTag}
                 displayUpdateBoardModal={displayUpdateBoardModal}

--- a/src/services/boardService.ts
+++ b/src/services/boardService.ts
@@ -46,34 +46,16 @@ export const getAllBoards = async (): Promise<any> => {
   return await api.get(`/boards`, config);
 };
 
-export const updateBoardImage = async ({
-  boardTag,
-  file,
-}: {
-  boardTag: string;
-  file: any;
-}): Promise<any> => {
-  await checkToken();
-
-  const config = {
-    headers: {
-      "Content-Type": "multipart/form-data",
-      Authorization: `Bearer ${localStorage.getItem(ACCESS_TOKEN)}`,
-    },
-  };
-
-  let fd = new FormData();
-  fd.append("file", file);
-
-  return await api.put(`boards/${boardTag}`, fd, config);
-};
-
-export const editBoardName = async ({
+export const editBoard = async ({
   boardTag,
   name,
+  file,
+  visibility,
 }: {
   boardTag: string;
   name: string;
+  file: any;
+  visibility: string;
 }): Promise<any> => {
   await checkToken();
 
@@ -85,7 +67,9 @@ export const editBoardName = async ({
   };
 
   let fd = new FormData();
-  fd.append("name", name);
+  fd.append("boardName", name);
+  file && fd.append("file", file);
+  fd.append("boardVisibility", visibility);
 
   return await api.put(`boards/${boardTag}`, fd, config);
 };

--- a/src/slice/boardSlice.ts
+++ b/src/slice/boardSlice.ts
@@ -194,29 +194,28 @@ const boardSlice = createSlice({
 
       localStorage.setItem("boardItem", JSON.stringify(item));
     },
-    updateBoardImage(
+    editBoardItem(
       state: any,
-      action: { payload: { boardTag: string; imageUrl: string | undefined } }
+      action: {
+        payload: {
+          boardTag: string;
+          name: string;
+          imageUrl: any;
+          visibility: string;
+        };
+      }
     ) {
-      const { boardTag, imageUrl } = action.payload;
-
-      const boardIndex = state.boardList.findIndex(
-        (board: Board) => board.boardTag === boardTag
-      );
-
-      state.boardList[boardIndex].imageUrl = imageUrl;
-    },
-    editBoardName(
-      state: any,
-      action: { payload: { boardTag: string; name: string } }
-    ) {
-      const { boardTag, name } = action.payload;
+      const { boardTag, name, imageUrl, visibility } = action.payload;
 
       const boardIndex = state.boardList.findIndex(
         (board: Board) => board.boardTag === boardTag
       );
 
       state.boardList[boardIndex].name = name;
+      state.boardList[boardIndex].imageUrl = imageUrl;
+      state.boardList[boardIndex].boardVisibility = visibility;
+
+      localStorage.setItem("boardList", JSON.stringify(state.boardList));
     },
     addCommentToTaskComments(
       state: any,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,6 @@
 export interface Board {
   boardTag: string;
+  boardVisibility: string;
   name: string;
   id: number;
   imageUrl: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     colors: {
+      "color-current": "currentColor",
       "color-border": "#BDBDBD",
       "color-light-border": "rgba(#BDBDBD, .2)",
       "text-p-color": "#333333",


### PR DESCRIPTION
## Pull Request Description
THULLO-52: Consume the update board api

## Changes Made
- I fixed the multiple display of the updateBoardModal
- I made the consumption of the updateBoard api to be used only once unlike before when i was calling it for different scenarios of update.
- I changed the layout of the updateBoardForm 



## How to Test
1. Click on the three dots inside the board
2. click on edit board on the modal that popped up if you want to edit the board or click outside the modal to close it
3. edit the board details you want to edit and save

## Checklist
- [ ] I have followed the project's code style guidelines -YES
- [ ] My changes are documented appropriately - YES
- [ ] I have added/updated tests for my changes -NO
- [ ] My code builds without any errors or warnings - YES
- [ ] My changes do not introduce any new linting errors or warnings - YES



